### PR TITLE
Add choiceDialog helper function

### DIFF
--- a/LuaCutscenes/Assets/LuaCutscenes/examples/example_talker.lua
+++ b/LuaCutscenes/Assets/LuaCutscenes/examples/example_talker.lua
@@ -16,6 +16,8 @@ function onTalk()
     walk(24)
     walk(-24, true, 0.1)
 
+    -- This is the old way of doing choices.
+    -- Using choiceDialog instead (shown below) is recommended as it is much simpler for bigger conversations.
     if choice("CH6_THEO_ASK_VACATION", "CH6_THEO_ASK_FAMILY") == 1 then
         say("CH6_THEO_SAY_VACATION")
 
@@ -25,6 +27,69 @@ function onTalk()
 
     jump()
     wait(2)
+
+    -- The new way of doing choices, recommended.
+    -- It accepts a table containing information about all possible choices and their requirements.
+    choiceDialog({
+        -- The most basic dialog choice.
+        -- The dialog key DIALOG_1 will be used for displaying the choice, then when you choose it, the dialog DIALOG_1_SAY will be shown.
+        { "DIALOG_1" },
+        {
+            -- This dialog requires that you had already chosen "DIALOG_1" before.
+            "DIALOG_1_PART_2",
+            requires = { "DIALOG_1" }
+        },
+        {
+            -- This dialog will always be available, no matter how many times it has been chosen.
+            "REPEATING",
+            repeatable = true
+        },
+        {
+            -- 'requires' can also be a function returning a bool. If this function returns false, the choice will not be available.
+            "RANDOM",
+            requires = function ()
+                return math.random() > 0.5
+            end,
+        },
+        {
+            -- There can be multiple requirements for the same choice.
+            -- All conditions need to be met at the same for this choice to show up.
+            "AFTER_1_AND_RANDOM",
+            requires = { "DIALOG_1", "RANDOM", function ()
+                return math.random() > 0.5
+            end},
+        },
+        {
+            -- This choice will not display a dialog, and instead run the code in 'onChosen'
+            "DIALOG_WITH_EFFECT",
+            onChosen = function ()
+                jump(0.2)
+                wait()
+                waitUntilOnGround()
+            end
+        },
+        {
+            --[[
+            This choice will be available after either DIALOG_1 or DIALOG_WITH_EFFECT gets used.
+            ctx is a table containing information about the current choice dialog.
+            ctx.usedDialogs is a table which stores which dialogs you already used, in the format {
+                ["DIALOG_KEY"] = true,
+                ...
+            }]]
+            "AFTER_1_OR_EFFECT",
+            requires = function (ctx)
+                return ctx.usedDialogs["DIALOG_1"] or ctx.usedDialogs["DIALOG_WITH_EFFECT"]
+            end
+        },
+        {
+            -- this choice will still display a dialog like normal, but also run code in 'onEnd' after the dialog finishes.
+            "DIALOG_CLOSE",
+            onEnd = function ()
+                -- call this function to close the choice dialog and allow the cutscene to continue.
+                closeChoiceDialog()
+            end
+        }
+    })
 
     enableMovement()
 end


### PR DESCRIPTION
Adds the `choiceDialog` helper function, which can be used to easily create complex conversations, in a way that's way more manageable than the `choice` function.

Usage explained in the `example_talker.lua` file