### PR TITLE
Fix postcard encoding issues

### DIFF
--- a/Helpers/MethodWrappers.cs
+++ b/Helpers/MethodWrappers.cs
@@ -202,5 +202,11 @@ namespace Celeste.Mod.LuaCutscenes
                 };
             }
         }
+
+        public static Postcard CreatePostcard(string dialog, string sfxIn, string sfxOut)
+            => new Postcard(Dialog.Get(dialog) ?? dialog, sfxIn, sfxOut);
+
+        public static Postcard CreatePostcard(string dialog, int area)
+            => new Postcard(Dialog.Get(dialog) ?? dialog, area);
     }
 }

--- a/LuaCutscenes/Assets/LuaCutscenes/helper_functions.lua
+++ b/LuaCutscenes/Assets/LuaCutscenes/helper_functions.lua
@@ -261,14 +261,12 @@ end
 -- @tparam any sfxIn effect when opening the postcard or area ID.
 -- @string[opt=nil] sfxOut Sound effect when closing the postcard. If not used then second argument is assumed to be area ID.
 function helpers.postcard(dialog, sfxIn, sfxOut)
-    local message = celeste.Dialog.Get(dialog) or dialog
     local postcard
 
     if sfxOut then
-        postcard = celeste.Postcard(message, sfxIn, sfxOut)
-
+        postcard = celeste.Mod[modName].MethodWrappers.CreatePostcard(dialog, sfxIn, sfxOut)
     else
-        postcard = celeste.Postcard(message, sfxIn)
+        postcard = celeste.Mod[modName].MethodWrappers.CreatePostcard(dialog, sfxIn)
     end
 
     getRoom():add(postcard)


### PR DESCRIPTION
when using language like Chinese, `postcard` will actually show lots of `?`, guessing encoding issues when marshalling the return value of `Dialog.Get` to lua, and it does.