### PR TITLE
Add helper function getNode(name) to allow easy access to Cutscene Nodes

### DIFF
--- a/LuaCutscenes/Assets/LuaCutscenes/helper_functions.lua
+++ b/LuaCutscenes/Assets/LuaCutscenes/helper_functions.lua
@@ -683,6 +683,14 @@ function helpers.getRoomCoordinatesOffset(x, y)
     end
 end
 
+--- Get a cutscene node with the given name.
+-- Can be referenced to obtain X and Y coordinates at node position.
+-- @string name The name of the desired cutscene node entity.
+-- @treturn CutsceneNode The cutscene node.
+function helpers.getNode(name)
+    return celeste.CutsceneNode.Find(tostring(name))
+end
+
 --- Set session flag.
 -- @string flag Flag to set.
 -- @bool value State of flag.


### PR DESCRIPTION
Added the getNode(name) function, which gets a CutsceneNode from the scene that matches a given name.

Cutscene Nodes are both simple and useful. Currently there is no easy way to utilize them in a Lua Cutscene. This helper function adds in this ability, making this powerful tool much more accessible for the average modder.

Example, the following code is sufficient to make Madeline walk to a point matching the X position of a placed node
```
local node = getNode("ozma_testnode")
walkTo(node.X)
```

I did not make changes to the Documentation, but if this gets accepted, I'm happy to contribute a short summary for it.